### PR TITLE
Making task path configurable externally

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,12 +5,14 @@ var handlebars = require('handlebars')
 var fs = require('fs')
 
 var taskTypeCache = {};
+var DEFAULT_TASK_PATH = "/src/tasks/"
+var taskPath
 
 var workflow =  {
 
-    
+
     discoverTaskType: function(taskType) {
-        var processRelativePath = path.join(process.cwd(), "/src/tasks/", taskType + ".js");
+        var processRelativePath = path.join(process.cwd(), taskPath, taskType + ".js");
         return fs.existsSync(processRelativePath) ? processRelativePath : "./tasks/" + taskType + ".js";
     },
 
@@ -28,6 +30,7 @@ var workflow =  {
     define: function (workflowDefinition) {
 
         debug("defining: %s", workflowDefinition.task)
+        taskPath = workflowDefinition.taskPath || DEFAULT_TASK_PATH
         var WorkflowType = workflow.getWorkflow(workflowDefinition.task)
 
         var wfInstance = WorkflowType(workflowDefinition)


### PR DESCRIPTION
I don't use the 'src' directory for my code. I don't want worksmith to force me to change it and all the references in my code. This change allows you to include in your WF definition the property:

```
{
...
'taskPath': 'my/task/path'
...
}

This gives more flexibility to the WF/tasks definition as you could have them separated in different directories.

If you don't specify that property it will still default to the original src/tasks path.
```
